### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,6 +66,8 @@ jobs:
       matrix:
         go-version: ["1.25", "1.26"]
     name: Build ${{ matrix.go-version == '1.26' && '(latest)' || '(old)' }}
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/1](https://github.com/PakaiWA/whatsmeow/security/code-scanning/1)

Add an explicit `permissions` block to the `build` job in `.github/workflows/go.yml`, setting only the minimum needed permission:

- `contents: read`

This is the best minimal fix because:
- It addresses exactly the flagged job (`build`) without altering behavior of other jobs.
- It preserves existing functionality (checkout/build/test/pre-commit only need repository read access).
- It avoids unintentionally changing privilege scope for jobs that already have custom permissions.

Edit location:
- File: `.github/workflows/go.yml`
- Region: `build` job definition, immediately after `name` (or before `steps`), aligned with job-level keys.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
