### PR TITLE
Potential fix for code scanning alert no. 19: Incorrect conversion between integer types

### DIFF
--- a/user.go
+++ b/user.go
@@ -746,7 +746,7 @@ func parseDeviceList(user types.JID, deviceNode waBinary.Node) []types.JID {
 	for _, device := range children {
 		deviceID, ok := device.AttrGetter().GetInt64("id", true)
 		isHosted := device.AttrGetter().Bool("is_hosted")
-		if device.Tag != "device" || !ok {
+		if device.Tag != "device" || !ok || deviceID < 0 || deviceID > 65535 {
 			continue
 		}
 		user.Device = uint16(deviceID)
@@ -770,7 +770,7 @@ func parseFBDeviceList(user types.JID, deviceList waBinary.Node) deviceCache {
 	devices := make([]types.JID, 0, len(children))
 	for _, device := range children {
 		deviceID, ok := device.AttrGetter().GetInt64("id", true)
-		if device.Tag != "device" || !ok {
+		if device.Tag != "device" || !ok || deviceID < 0 || deviceID > 65535 {
 			continue
 		}
 		user.Device = uint16(deviceID)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/19](https://github.com/PakaiWA/whatsmeow/security/code-scanning/19)

The safest fix is to add explicit constant bounds checks before converting `int64` to `uint16`, and skip invalid entries. This preserves existing behavior (invalid devices are already skipped with `continue`) while preventing truncation/wraparound.

Best concrete change:
- In `user.go`, inside both loops in:
  - `parseDeviceList` (around current `user.Device = uint16(deviceID)`)
  - `parseFBDeviceList` (around current `user.Device = uint16(deviceID)`)
- Extend the existing `if` guard to reject values outside `0..65535`:
  - `if device.Tag != "device" || !ok || deviceID < 0 || deviceID > 65535 { continue }`
- Keep conversion only after the guard.

No new imports are required (using numeric constants avoids adding `math`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
