### PR TITLE
Potential fix for code scanning alert no. 2: Size computation for allocation may overflow

### DIFF
--- a/reportingtoken.go
+++ b/reportingtoken.go
@@ -12,6 +12,7 @@ import (
 	_ "embed"
 	"encoding/binary"
 	"encoding/json"
+	"math"
 	"sort"
 	"sync"
 
@@ -119,7 +120,14 @@ func extractReportingTokenContent(data []byte, config []reportingField) []byte {
 				i += 8
 			case wireBytes:
 				l, n := binary.Uvarint(data[i:])
-				i += n + int(l)
+				if n <= 0 || l > uint64(math.MaxInt) || i > len(data)-n {
+					return nil
+				}
+				next := i + n + int(l)
+				if next < i || next > len(data) {
+					return nil
+				}
+				i = next
 			case wire32bit:
 				i += 4
 			default:
@@ -137,14 +145,24 @@ func extractReportingTokenContent(data []byte, config []reportingField) []byte {
 			fields = append(fields, field{Num: fieldNum, Bytes: data[fieldStart:i]})
 		case wireBytes:
 			l, n := binary.Uvarint(data[i:])
+			if n <= 0 || l > uint64(math.MaxInt) || i > len(data)-n {
+				return nil
+			}
 			valStart := i + n
 			valEnd := valStart + int(l)
+			if valEnd < valStart || valEnd > len(data) {
+				return nil
+			}
 			if fieldCfg.IsMessage || len(fieldCfg.Subfields) > 0 {
 				// Recursively extract subfields
 				sub := extractReportingTokenContent(data[valStart:valEnd], fieldCfg.Subfields)
 				if len(sub) > 0 {
 					// Re-encode tag and length
-					buf := make([]byte, 0, tagLen+n+len(sub))
+					baseCap := tagLen + n
+					if baseCap < 0 || len(sub) > math.MaxInt-baseCap {
+						return nil
+					}
+					buf := make([]byte, 0, baseCap+len(sub))
 					tagBuf := make([]byte, binary.MaxVarintLen64)
 					tagN := binary.PutUvarint(tagBuf, tag)
 					lenBuf := make([]byte, binary.MaxVarintLen64)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/2](https://github.com/PakaiWA/whatsmeow/security/code-scanning/2)

Use explicit overflow-safe bounds checks before computing allocation capacities and before forming slice indexes from decoded lengths.

Best fix (without changing functionality): in `extractReportingTokenContent` (`reportingtoken.go`), add:
1. validation for varint length decode (`n > 0`);
2. bounds/overflow checks when converting `l` (`uint64`) to `int` and computing `valStart/valEnd`;
3. overflow check before `make([]byte, 0, tagLen+n+len(sub))` by ensuring `tagLen+n` does not overflow and `len(sub) <= maxInt-(tagLen+n)`.

This keeps behavior identical for valid inputs while safely bailing out (`return nil`) on malformed/oversized data. No new dependencies are needed; only standard library `math` import is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
