### PR TITLE
Potential fix for code scanning alert no. 5: Size computation for allocation may overflow

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 )
 
@@ -108,10 +109,14 @@ func DecryptFile(key, iv []byte, file File) error {
 Encrypt is a function that encrypts plaintext with a given key and an optional initialization vector(iv).
 */
 func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
-	sizeOfLastBlock := len(plaintext) % aes.BlockSize
+	plaintextLen := len(plaintext)
+	sizeOfLastBlock := plaintextLen % aes.BlockSize
 	paddingLen := aes.BlockSize - sizeOfLastBlock
-	plaintextStart := plaintext[:len(plaintext)-sizeOfLastBlock]
-	lastBlock := append(plaintext[len(plaintext)-sizeOfLastBlock:], bytes.Repeat([]byte{byte(paddingLen)}, paddingLen)...)
+	if plaintextLen > math.MaxInt-paddingLen {
+		return nil, fmt.Errorf("plaintext too large: %d", plaintextLen)
+	}
+	plaintextStart := plaintext[:plaintextLen-sizeOfLastBlock]
+	lastBlock := append(plaintext[plaintextLen-sizeOfLastBlock:], bytes.Repeat([]byte{byte(paddingLen)}, paddingLen)...)
 
 	if len(plaintextStart)%aes.BlockSize != 0 {
 		panic(fmt.Errorf("plaintext is not the correct size: %d %% %d != 0", len(plaintextStart), aes.BlockSize))
@@ -125,9 +130,14 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	totalWithoutIV := plaintextLen + paddingLen
 	var ciphertext []byte
 	if iv == nil {
-		ciphertext = make([]byte, aes.BlockSize+len(plaintext)+paddingLen)
+		if plaintextLen > math.MaxInt-paddingLen-aes.BlockSize {
+			return nil, fmt.Errorf("plaintext too large: %d", plaintextLen)
+		}
+		totalWithIV := aes.BlockSize + totalWithoutIV
+		ciphertext = make([]byte, totalWithIV)
 		iv := ciphertext[:aes.BlockSize]
 		if _, err := io.ReadFull(rand.Reader, iv); err != nil {
 			return nil, err
@@ -137,7 +147,7 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		cbc.CryptBlocks(ciphertext[aes.BlockSize:], plaintextStart)
 		cbc.CryptBlocks(ciphertext[aes.BlockSize+len(plaintextStart):], lastBlock)
 	} else {
-		ciphertext = make([]byte, len(plaintext)+paddingLen, len(plaintext)+paddingLen+10)
+		ciphertext = make([]byte, totalWithoutIV, totalWithoutIV+10)
 
 		cbc := cipher.NewCBCEncrypter(block, iv)
 		cbc.CryptBlocks(ciphertext, plaintextStart)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/5](https://github.com/PakaiWA/whatsmeow/security/code-scanning/5)

General fix: add explicit overflow-safe size checks before any allocation size arithmetic derived from potentially large input lengths, and return an error if bounds are exceeded.

Best fix here (without changing functionality): in `util/cbcutil/cbc.go` inside `Encrypt`, compute `plaintextLen := len(plaintext)` once and validate:
- `plaintextLen <= math.MaxInt - paddingLen` (for `len(plaintext)+paddingLen`)
- and, when `iv == nil`, also `plaintextLen <= math.MaxInt - paddingLen - aes.BlockSize` (for `aes.BlockSize+len(plaintext)+paddingLen`)

Then use precomputed safe totals for `make`. This preserves behavior for valid sizes and prevents overflow panics/wraparound.  
Needed changes:
- Add `math` import in `util/cbcutil/cbc.go`.
- Edit `Encrypt` region around lines 110–141 to add checks and use checked totals.

No change is required in `appstate/encode.go` for this specific sink fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
