### PR TITLE
Potential fix for code scanning alert no. 6: Size computation for allocation may overflow

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 )
 
@@ -125,9 +126,17 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if len(plaintext) > math.MaxInt-paddingLen {
+		return nil, fmt.Errorf("plaintext is too large")
+	}
+	ciphertextLen := len(plaintext) + paddingLen
+
 	var ciphertext []byte
 	if iv == nil {
-		ciphertext = make([]byte, aes.BlockSize+len(plaintext)+paddingLen)
+		if ciphertextLen > math.MaxInt-aes.BlockSize {
+			return nil, fmt.Errorf("plaintext is too large")
+		}
+		ciphertext = make([]byte, aes.BlockSize+ciphertextLen)
 		iv := ciphertext[:aes.BlockSize]
 		if _, err := io.ReadFull(rand.Reader, iv); err != nil {
 			return nil, err
@@ -137,7 +146,10 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		cbc.CryptBlocks(ciphertext[aes.BlockSize:], plaintextStart)
 		cbc.CryptBlocks(ciphertext[aes.BlockSize+len(plaintextStart):], lastBlock)
 	} else {
-		ciphertext = make([]byte, len(plaintext)+paddingLen, len(plaintext)+paddingLen+10)
+		if ciphertextLen > math.MaxInt-10 {
+			return nil, fmt.Errorf("plaintext is too large")
+		}
+		ciphertext = make([]byte, ciphertextLen, ciphertextLen+10)
 
 		cbc := cipher.NewCBCEncrypter(block, iv)
 		cbc.CryptBlocks(ciphertext, plaintextStart)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/6](https://github.com/PakaiWA/whatsmeow/security/code-scanning/6)

Add explicit integer-overflow guards in `util/cbcutil/cbc.go` inside `Encrypt` before any allocation-size arithmetic is used. Compute a checked `ciphertextLen` once, then reuse it in both branches (`iv == nil` and `iv != nil`) so behavior is unchanged except that oversized inputs return an error instead of risking overflow/panic.

Best concrete fix (single-file):
- **File:** `util/cbcutil/cbc.go`
- **Region:** `Encrypt` function, after key setup and before `make(...)` calls.
- **Changes:**
  1. Import `math`.
  2. Add checks:
     - `if len(plaintext) > math.MaxInt-paddingLen` → error
     - set `ciphertextLen := len(plaintext) + paddingLen`
     - `if iv == nil && ciphertextLen > math.MaxInt-aes.BlockSize` → error
  3. Replace raw arithmetic in `make` with checked values:
     - `make([]byte, aes.BlockSize+ciphertextLen)` for nil IV
     - `make([]byte, ciphertextLen, ciphertextLen+10)` for non-nil IV
       (with a guard for capacity overflow: `ciphertextLen > math.MaxInt-10`)

No functionality change for valid inputs; only adds safe failure for pathological oversized inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
