### PR TITLE
Potential fix for code scanning alert no. 7: Incorrect conversion between integer types

### DIFF
--- a/binary/attrs.go
+++ b/binary/attrs.go
@@ -8,6 +8,7 @@ package binary
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -133,6 +134,11 @@ func (au *AttrUtility) GetUnixMilli(key string, require bool) (time.Time, bool) 
 	}
 }
 
+const (
+	maxInt = int64(^uint(0) >> 1)
+	minInt = -maxInt - 1
+)
+
 // OptionalString returns the string under the given key.
 func (au *AttrUtility) OptionalString(key string) string {
 	strVal, _ := au.GetString(key, false)
@@ -148,11 +154,19 @@ func (au *AttrUtility) String(key string) string {
 
 func (au *AttrUtility) OptionalInt(key string) int {
 	val, _ := au.GetInt64(key, false)
+	if val > maxInt || val < minInt {
+		au.Errors = append(au.Errors, fmt.Errorf("value in attribute '%s' (%d) is out of int range [%d, %d]", key, val, math.MinInt, math.MaxInt))
+		return 0
+	}
 	return int(val)
 }
 
 func (au *AttrUtility) Int(key string) int {
 	val, _ := au.GetInt64(key, true)
+	if val > maxInt || val < minInt {
+		au.Errors = append(au.Errors, fmt.Errorf("value in attribute '%s' (%d) is out of int range [%d, %d]", key, val, math.MinInt, math.MaxInt))
+		return 0
+	}
 	return int(val)
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/7](https://github.com/PakaiWA/whatsmeow/security/code-scanning/7)

The safest fix without changing intended behavior is to add explicit `int` range checks before converting from `int64` to `int`, using compile-time constants for platform `int` bounds, and append an error when out of range. This preserves existing API/signatures and error-collection style, while preventing truncation.

In `binary/attrs.go`:
- Add `math` import.
- Define `maxInt` and `minInt` constants derived from word size.
- Update `OptionalInt` and `Int` to:
  1. parse via existing `GetInt64`,
  2. verify `val` is within `[minInt, maxInt]`,
  3. append a descriptive error and return `0` if out of range,
  4. otherwise safely convert to `int`.

This is the minimal and best fix because it keeps `GetInt64` behavior unchanged and addresses the exact vulnerable sinks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
