### PR TITLE
Potential fix for code scanning alert no. 8: Incorrect conversion between integer types

### DIFF
--- a/binary/attrs.go
+++ b/binary/attrs.go
@@ -148,11 +148,23 @@ func (au *AttrUtility) String(key string) string {
 
 func (au *AttrUtility) OptionalInt(key string) int {
 	val, _ := au.GetInt64(key, false)
+	maxInt := int64(^uint(0) >> 1)
+	minInt := -maxInt - 1
+	if val < minInt || val > maxInt {
+		au.Errors = append(au.Errors, fmt.Errorf("int value in attribute '%s' out of range: %d", key, val))
+		return 0
+	}
 	return int(val)
 }
 
 func (au *AttrUtility) Int(key string) int {
 	val, _ := au.GetInt64(key, true)
+	maxInt := int64(^uint(0) >> 1)
+	minInt := -maxInt - 1
+	if val < minInt || val > maxInt {
+		au.Errors = append(au.Errors, fmt.Errorf("int value in attribute '%s' out of range: %d", key, val))
+		return 0
+	}
 	return int(val)
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/8](https://github.com/PakaiWA/whatsmeow/security/code-scanning/8)

The best fix is to keep parsing as `int64` (which is already correct for robust decoding) and add explicit range checks before converting to `int` in `OptionalInt` and `Int`.

In `binary/attrs.go`, update:
- `OptionalInt(key string) int`
- `Int(key string) int`

so they:
1. call `GetInt64` as today,
2. compute `maxInt := int64(^uint(0) >> 1)` and `minInt := -maxInt - 1`,
3. verify `val` is within `[minInt, maxInt]`,
4. append an error to `au.Errors` and return `0` if out of range,
5. otherwise return `int(val)`.

This preserves existing behavior for valid values while preventing silent truncation and satisfying CodeQL’s requirement for an explicit upper/lower bound check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
