### PR TITLE
Potential fix for code scanning alert no. 9: Incorrect conversion between integer types

### DIFF
--- a/group.go
+++ b/group.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	waBinary "github.com/PakaiWA/whatsmeow/binary"
@@ -780,7 +781,12 @@ func (cli *Client) parseGroupNode(groupNode *waBinary.Node) (*types.GroupInfo, e
 			group.IsLocked = true
 		case "ephemeral":
 			group.IsEphemeral = true
-			group.DisappearingTimer = uint32(childAG.Uint64("expiration"))
+			expiration := childAG.Uint64("expiration")
+			if expiration <= math.MaxUint32 {
+				group.DisappearingTimer = uint32(expiration)
+			} else {
+				childAG.Errors = append(childAG.Errors, fmt.Errorf("failed to parse uint in attribute '%s': value %d overflows uint32", "expiration", expiration))
+			}
 		case "member_add_mode":
 			modeBytes, _ := child.Content.([]byte)
 			group.MemberAddMode = types.GroupMemberAddMode(modeBytes)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/9](https://github.com/PakaiWA/whatsmeow/security/code-scanning/9)

General fix: avoid narrowing-conversion from a wider parsed integer type unless you either (a) parse directly at the target width, or (b) perform explicit bounds checks before conversion.

Best fix here without changing existing behavior broadly: in `group.go` at the `"ephemeral"` case, read the expiration as `uint64`, compare against `math.MaxUint32`, and only then assign `group.DisappearingTimer = uint32(expiration)`. If out of range, record a parse/validation error through `childAG.Errors` so existing `!childAG.OK()` warning path remains effective.

Changes needed:
- **File:** `group.go`
  - Add `math` import.
  - Replace direct cast at line 783 with checked conversion plus error append using `fmt.Errorf` (already imported).

No changes are required in `binary/attrs.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
