### PR TITLE
Potential fix for code scanning alert no. 10: Incorrect conversion between integer types

### DIFF
--- a/group.go
+++ b/group.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	waBinary "github.com/PakaiWA/whatsmeow/binary"
@@ -960,7 +961,12 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 			link := InviteLinkPrefix + cag.String("code")
 			evt.NewInviteLink = &link
 		case "ephemeral":
-			timer := uint32(cag.Uint64("expiration"))
+			expiration := cag.Uint64("expiration")
+			timer := uint32(expiration)
+			if expiration > math.MaxUint32 {
+				cag.Errors = append(cag.Errors, fmt.Errorf("value of attribute 'expiration' overflows uint32: %d", expiration))
+				timer = math.MaxUint32
+			}
 			evt.Ephemeral = &types.GroupEphemeral{
 				IsEphemeral:       true,
 				DisappearingTimer: timer,


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/10](https://github.com/PakaiWA/whatsmeow/security/code-scanning/10)

Use an explicit upper-bound check before converting `uint64` to `uint32` in `group.go` at the `case "ephemeral"` block. Keep existing behavior as much as possible while preventing truncation. The best minimal fix is:

- Read `expiration` as `uint64`.
- If it is greater than `math.MaxUint32`, record an attribute parse error (so existing error handling paths can react) and clamp/fallback safely.
- Otherwise convert to `uint32`.

This preserves functionality for valid inputs and avoids silent wraparound on invalid oversized inputs.  
Changes needed:

- **File:** `group.go`
- **Imports:** add Go standard library `math`.
- **Code region:** switch `case "ephemeral"` around current line 963.
- **Implementation detail:** create local `expiration := cag.Uint64("expiration")`, check `if expiration > math.MaxUint32`, append an error to `cag.Errors`, and set timer safely; else cast.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
