### PR TITLE
Potential fix for code scanning alert no. 12: Incorrect conversion between integer types

### DIFF
--- a/store/clientpayload.go
+++ b/store/clientpayload.go
@@ -27,15 +27,15 @@ type WAVersionContainer [3]uint32
 
 // ParseVersion parses a version string (three dot-separated numbers) into a WAVersionContainer.
 func ParseVersion(version string) (parsed WAVersionContainer, err error) {
-	var part1, part2, part3 int
+	var part1, part2, part3 uint64
 	if parts := strings.Split(version, "."); len(parts) != 3 {
 		err = fmt.Errorf("'%s' doesn't contain three dot-separated parts", version)
-	} else if part1, err = strconv.Atoi(parts[0]); err != nil {
-		err = fmt.Errorf("first part of '%s' is not a number: %w", version, err)
-	} else if part2, err = strconv.Atoi(parts[1]); err != nil {
-		err = fmt.Errorf("second part of '%s' is not a number: %w", version, err)
-	} else if part3, err = strconv.Atoi(parts[2]); err != nil {
-		err = fmt.Errorf("third part of '%s' is not a number: %w", version, err)
+	} else if part1, err = strconv.ParseUint(parts[0], 10, 32); err != nil {
+		err = fmt.Errorf("first part of '%s' is not a valid uint32 number: %w", version, err)
+	} else if part2, err = strconv.ParseUint(parts[1], 10, 32); err != nil {
+		err = fmt.Errorf("second part of '%s' is not a valid uint32 number: %w", version, err)
+	} else if part3, err = strconv.ParseUint(parts[2], 10, 32); err != nil {
+		err = fmt.Errorf("third part of '%s' is not a valid uint32 number: %w", version, err)
 	} else {
 		parsed = WAVersionContainer{uint32(part1), uint32(part2), uint32(part3)}
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/12](https://github.com/PakaiWA/whatsmeow/security/code-scanning/12)

Use fixed-width parsing that matches the destination type and reject invalid values at parse time.

Best fix in `store/clientpayload.go` within `ParseVersion` (lines 29–41 shown): replace `strconv.Atoi` (`int`) parsing with `strconv.ParseUint(..., 10, 32)` for each version component, then cast the returned `uint64` to `uint32` only after successful parse. This preserves intended functionality (parse three dot-separated numeric parts) while preventing negative values and out-of-range values from being silently converted. No new imports are required (`strconv` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
