### PR TITLE
Potential fix for code scanning alert no. 14: Incorrect conversion between integer types

### DIFF
--- a/types/jid.go
+++ b/types/jid.go
@@ -172,13 +172,13 @@ func ParseJID(jid string) (JID, error) {
 		if len(parts) > 2 {
 			return parsedJID, fmt.Errorf("unexpected number of colons in JID")
 		}
-		agent, err := strconv.Atoi(parts[0])
+		agent, err := strconv.ParseUint(parts[0], 10, 8)
 		if err != nil {
 			return parsedJID, fmt.Errorf("failed to parse device from JID: %w", err)
 		}
 		parsedJID.RawAgent = uint8(agent)
 		if len(parts) == 2 {
-			device, err := strconv.Atoi(parts[1])
+			device, err := strconv.ParseUint(parts[1], 10, 16)
 			if err != nil {
 				return parsedJID, fmt.Errorf("failed to parse device from JID: %w", err)
 			}
@@ -190,7 +190,7 @@ func ParseJID(jid string) (JID, error) {
 			return parsedJID, fmt.Errorf("unexpected number of colons in JID")
 		}
 		parsedJID.User = parts[0]
-		device, err := strconv.Atoi(parts[1])
+		device, err := strconv.ParseUint(parts[1], 10, 16)
 		if err != nil {
 			return parsedJID, fmt.Errorf("failed to parse device from JID: %w", err)
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/14](https://github.com/PakaiWA/whatsmeow/security/code-scanning/14)

Use parse functions with explicit bit sizes and unsigned semantics for these fields, instead of `Atoi` + narrowing cast.

Best fix in `types/jid.go` (inside `ParseJID`):
- Replace:
  - `strconv.Atoi(parts[0])` for `agent` with `strconv.ParseUint(parts[0], 10, 8)`, then cast `uint8(parsed)`.
  - `strconv.Atoi(parts[1])` for `device` with `strconv.ParseUint(parts[1], 10, 16)`, then cast `uint16(parsed)`.
  - Same replacement for the `device` parse in the `':'` branch.
- Keep existing error-return behavior/messages (or as close as possible) so functionality remains the same except now invalid/out-of-range values fail parsing instead of truncating.

No new imports or dependencies are needed (`strconv` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
