### PR TITLE
Potential fix for code scanning alert no. 15: Incorrect conversion between integer types

### DIFF
--- a/types/jid.go
+++ b/types/jid.go
@@ -178,7 +178,7 @@ func ParseJID(jid string) (JID, error) {
 		}
 		parsedJID.RawAgent = uint8(agent)
 		if len(parts) == 2 {
-			device, err := strconv.Atoi(parts[1])
+			device, err := strconv.ParseUint(parts[1], 10, 16)
 			if err != nil {
 				return parsedJID, fmt.Errorf("failed to parse device from JID: %w", err)
 			}
@@ -190,7 +190,7 @@ func ParseJID(jid string) (JID, error) {
 			return parsedJID, fmt.Errorf("unexpected number of colons in JID")
 		}
 		parsedJID.User = parts[0]
-		device, err := strconv.Atoi(parts[1])
+		device, err := strconv.ParseUint(parts[1], 10, 16)
 		if err != nil {
 			return parsedJID, fmt.Errorf("failed to parse device from JID: %w", err)
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/15](https://github.com/PakaiWA/whatsmeow/security/code-scanning/15)

Use `strconv.ParseUint(..., 10, 16)` instead of `strconv.Atoi(...)` for values that are ultimately stored in `uint16`. This ensures parsing fails for negative values and for any number outside `0..65535`, eliminating truncation/wrap on conversion and preserving behavior (invalid input still returns an error).

In `types/jid.go`, update both device parsing sites:
- In the dotted-user branch (`if len(parts) == 2`), replace `Atoi` with `ParseUint` and then cast `uint64` to `uint16`.
- In the colon-user branch (`strings.ContainsRune(parsedJID.User, ':')`), do the same replacement.

No new imports are required since `strconv` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
