### PR TITLE
Potential fix for code scanning alert no. 16: Incorrect conversion between integer types

### DIFF
--- a/types/jid.go
+++ b/types/jid.go
@@ -178,7 +178,7 @@ func ParseJID(jid string) (JID, error) {
 		}
 		parsedJID.RawAgent = uint8(agent)
 		if len(parts) == 2 {
-			device, err := strconv.Atoi(parts[1])
+			device, err := strconv.ParseUint(parts[1], 10, 16)
 			if err != nil {
 				return parsedJID, fmt.Errorf("failed to parse device from JID: %w", err)
 			}
@@ -190,7 +190,7 @@ func ParseJID(jid string) (JID, error) {
 			return parsedJID, fmt.Errorf("unexpected number of colons in JID")
 		}
 		parsedJID.User = parts[0]
-		device, err := strconv.Atoi(parts[1])
+		device, err := strconv.ParseUint(parts[1], 10, 16)
 		if err != nil {
 			return parsedJID, fmt.Errorf("failed to parse device from JID: %w", err)
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/16](https://github.com/PakaiWA/whatsmeow/security/code-scanning/16)

Use width-specific parsing for values later stored in fixed-width integer fields.

Best fix in `types/jid.go` within `ParseJID`:
- Replace `strconv.Atoi` calls used for `device` values (line regions around 181 and 193) with `strconv.ParseUint(..., 10, 16)`.
- Assign to `parsedJID.Device` via `uint16(parsedDevice)` where `parsedDevice` is the `uint64` result from `ParseUint`.
- Keep existing error behavior/messages.
  
This preserves functionality for valid inputs while preventing truncation/underflow behavior for out-of-range or negative values (those now correctly return parse errors).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
