### PR TITLE
Potential fix for code scanning alert no. 3: Size computation for allocation may overflow

### DIFF
--- a/socket/framesocket.go
+++ b/socket/framesocket.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -133,8 +134,12 @@ func (fs *FrameSocket) SendFrame(data []byte) error {
 	}
 
 	headerLength := len(fs.Header)
+	if headerLength < 0 || dataLength < 0 || headerLength > math.MaxInt-FrameLengthSize-dataLength {
+		return fmt.Errorf("%w (got %d bytes, max %d bytes)", ErrFrameTooLarge, len(data), FrameMaxSize)
+	}
 	// Whole frame is header + 3 bytes for length + data
-	wholeFrame := make([]byte, headerLength+FrameLengthSize+dataLength)
+	totalLength := headerLength + FrameLengthSize + dataLength
+	wholeFrame := make([]byte, totalLength)
 
 	// Copy the header if it's there
 	if fs.Header != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/3](https://github.com/PakaiWA/whatsmeow/security/code-scanning/3)

General fix: before allocating with a computed size, validate each component and explicitly guard the addition from overflowing `int`. Keep behavior unchanged for valid sizes; return an existing “too large” style error when computed frame size is invalid.

Best fix here (single location): in `socket/framesocket.go`, inside `SendFrame`, add:
1. an import of `math`,
2. an overflow-safe check before `make`:
   - reject negative lengths (defensive),
   - reject if `headerLength > math.MaxInt - FrameLengthSize - dataLength`,
3. compute `totalLength := headerLength + FrameLengthSize + dataLength` only after checks, then allocate with `make([]byte, totalLength)`.

This addresses both alert variants because both flows reach the same sink (`SendFrame` allocation).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
