### PR TITLE
Potential fix for code scanning alert no. 17: Incorrect conversion between integer types

### DIFF
--- a/update.go
+++ b/update.go
@@ -56,7 +56,7 @@ func GetLatestVersion(ctx context.Context, httpClient *http.Client) (*store.WAVe
 		return nil, fmt.Errorf("unexpected response with status %d: %s", resp.StatusCode, data)
 	} else if match := clientVersionRegex.FindSubmatch(data); len(match) == 0 {
 		return nil, fmt.Errorf("version number not found")
-	} else if parsedVer, err := strconv.ParseInt(string(match[1]), 10, 64); err != nil {
+	} else if parsedVer, err := strconv.ParseUint(string(match[1]), 10, 32); err != nil {
 		return nil, fmt.Errorf("failed to parse version number: %w", err)
 	} else {
 		return &store.WAVersionContainer{2, 3000, uint32(parsedVer)}, nil


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/17](https://github.com/PakaiWA/whatsmeow/security/code-scanning/17)

Use an unsigned parse with the target bit size to prevent unsafe narrowing casts. Specifically in `update.go`, replace `strconv.ParseInt(..., 64)` with `strconv.ParseUint(..., 32)`, then cast the resulting value to `uint32` when constructing `store.WAVersionContainer`.

Why this is best:
- It preserves behavior for valid inputs.
- It rejects out-of-range values at parse time (`ErrRange`) instead of silently truncating.
- It aligns parse type/size with the destination type, which is exactly what CodeQL recommends.
- No additional dependencies are needed, and existing imports remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
