### PR TITLE
Potential fix for code scanning alert no. 20: Size computation for allocation may overflow

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -159,7 +159,7 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		if paddedLen > math.MaxInt-10 {
 			return nil, errors.New("plaintext too large")
 		}
-		ciphertext = make([]byte, paddedLen, paddedLen+10)
+		ciphertext = make([]byte, paddedLen)
 
 		cbc := cipher.NewCBCEncrypter(block, iv)
 		cbc.CryptBlocks(ciphertext, plaintextStart)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/20](https://github.com/PakaiWA/whatsmeow/security/code-scanning/20)

General fix approach: avoid allocation size arithmetic that can overflow by (1) checking bounds immediately before each allocation-relevant expression, and (2) removing unnecessary capacity math when it is not functionally required.

Best single fix here without changing behavior: in `util/cbcutil/cbc.go`, in `Encrypt`’s `iv != nil` branch, replace `make([]byte, paddedLen, paddedLen+10)` with `make([]byte, paddedLen)`. The extra capacity `+10` is not used by subsequent logic in this function (the slice is only written in-place via CBC block encryption and returned), so removing it preserves functionality while eliminating the overflow-prone expression flagged by CodeQL (`paddedLen+10`). Keep existing bounds checks unchanged.

File/region to change:
- `util/cbcutil/cbc.go`, inside `Encrypt`, `else` branch for `iv != nil`, around current line 162.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
