### PR TITLE
Potential fix for code scanning alert no. 22: Size computation for allocation may overflow

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -159,7 +159,7 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		if paddedLen > math.MaxInt-10 {
 			return nil, errors.New("plaintext too large")
 		}
-		ciphertext = make([]byte, paddedLen, paddedLen+10)
+		ciphertext = make([]byte, paddedLen)
 
 		cbc := cipher.NewCBCEncrypter(block, iv)
 		cbc.CryptBlocks(ciphertext, plaintextStart)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/22](https://github.com/PakaiWA/whatsmeow/security/code-scanning/22)

Best fix: avoid risky/needless arithmetic in allocation size/capacity and keep a direct guard pattern around values used by `make`.

In `util/cbcutil/cbc.go`, inside `Encrypt`:
- Keep existing overflow guards.
- In the `iv != nil` branch, replace `make([]byte, paddedLen, paddedLen+10)` with `make([]byte, paddedLen)`.
  - This preserves functionality (the buffer is only written up to `paddedLen`; no append/growth is used in that branch).
  - It removes the extra `+10` arithmetic from allocation arguments, which is what CodeQL flags.
- No import changes needed.

This is the smallest safe change and does not alter encryption output format or behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
