### PR TITLE
Potential fix for code scanning alert no. 24: Size computation for allocation may overflow

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -139,13 +139,12 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	totalWithoutIV := plaintextLen + paddingLen
 	var ciphertext []byte
 	if iv == nil {
 		if plaintextLen > math.MaxInt-paddingLen-aes.BlockSize {
 			return nil, fmt.Errorf("plaintext too large: %d", plaintextLen)
 		}
-		totalWithIV := aes.BlockSize + totalWithoutIV
+		totalWithIV := paddedLen + aes.BlockSize
 		ciphertext = make([]byte, totalWithIV)
 		iv := ciphertext[:aes.BlockSize]
 		if _, err := io.ReadFull(rand.Reader, iv); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/24](https://github.com/PakaiWA/whatsmeow/security/code-scanning/24)

General fix: ensure allocation size is computed from already range-checked values, and avoid duplicated arithmetic chains involving tainted length-derived intermediates near `make`.

Best concrete fix in `util/cbcutil/cbc.go`:
- In `Encrypt`, stop using `totalWithoutIV` for the IV branch size calculation.
- Reuse `paddedLen` (already computed with overflow check) and compute `totalWithIV := paddedLen + aes.BlockSize` only after the existing `paddedLen > math.MaxInt-aes.BlockSize` guard.
- Allocate with this safe `totalWithIV`.

This keeps behavior unchanged while making the overflow safety explicit at the exact sink CodeQL flagged.

No changes are required in `appstate/encode.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
