### PR TITLE
Potential fix for code scanning alert no. 26: Incorrect conversion between integer types

### DIFF
--- a/group.go
+++ b/group.go
@@ -967,10 +967,11 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 			evt.NewInviteLink = &link
 		case "ephemeral":
 			expiration := cag.Uint64("expiration")
-			timer := uint32(expiration)
-			if expiration > math.MaxUint32 {
+			timer := uint32(math.MaxUint32)
+			if expiration <= math.MaxUint32 {
+				timer = uint32(expiration)
+			} else {
 				cag.Errors = append(cag.Errors, fmt.Errorf("value of attribute 'expiration' overflows uint32: %d", expiration))
-				timer = math.MaxUint32
 			}
 			evt.Ephemeral = &types.GroupEphemeral{
 				IsEphemeral:       true,


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/26](https://github.com/PakaiWA/whatsmeow/security/code-scanning/26)

The best fix is to move the `uint32` conversion so it only happens after an explicit upper-bound check. This preserves existing behavior (including error reporting and clamping) while eliminating the unsafe conversion pattern.

In `group.go` around the `"ephemeral"` case (shown lines 968–974), replace:

- `timer := uint32(expiration)` followed by overflow check

with:

- initialize `timer` to `math.MaxUint32`,
- if `expiration <= math.MaxUint32`, set `timer = uint32(expiration)`,
- else append the same overflow error.

This avoids any narrowing conversion on out-of-range values and keeps output semantics unchanged.

No changes are required in `binary/attrs.go` for this specific finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
