### PR TITLE
Potential fix for code scanning alert no. 27: Incorrect conversion between integer types

### DIFF
--- a/binary/attrs.go
+++ b/binary/attrs.go
@@ -152,25 +152,25 @@ func (au *AttrUtility) String(key string) string {
 }
 
 func (au *AttrUtility) OptionalInt(key string) int {
-	val, _ := au.GetInt64(key, false)
-	maxInt := int64(^uint(0) >> 1)
-	minInt := -maxInt - 1
-	if val < minInt || val > maxInt {
-		au.Errors = append(au.Errors, fmt.Errorf("int value in attribute '%s' out of range: %d", key, val))
+	if strVal, ok := au.GetString(key, false); !ok {
 		return 0
+	} else if intVal, err := strconv.ParseInt(strVal, 10, strconv.IntSize); err != nil {
+		au.Errors = append(au.Errors, fmt.Errorf("failed to parse int in attribute '%s': %w", key, err))
+		return 0
+	} else {
+		return int(intVal)
 	}
-	return int(val)
 }
 
 func (au *AttrUtility) Int(key string) int {
-	val, _ := au.GetInt64(key, true)
-	maxInt := int64(^uint(0) >> 1)
-	minInt := -maxInt - 1
-	if val < minInt || val > maxInt {
-		au.Errors = append(au.Errors, fmt.Errorf("int value in attribute '%s' out of range: %d", key, val))
+	if strVal, ok := au.GetString(key, true); !ok {
 		return 0
+	} else if intVal, err := strconv.ParseInt(strVal, 10, strconv.IntSize); err != nil {
+		au.Errors = append(au.Errors, fmt.Errorf("failed to parse int in attribute '%s': %w", key, err))
+		return 0
+	} else {
+		return int(intVal)
 	}
-	return int(val)
 }
 
 func (au *AttrUtility) Int64(key string) int64 {


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/27](https://github.com/PakaiWA/whatsmeow/security/code-scanning/27)

To fix this in a robust, analyzer-friendly way, avoid parsing to `int64` and then narrowing to `int`. Instead, parse directly to the destination width (`int`) by using `strconv.ParseInt` with bit size `strconv.IntSize` and convert the result to `int`. This removes the risky narrowing path and preserves behavior across 32-bit/64-bit platforms.

In `binary/attrs.go`, update both:
- `OptionalInt` (around lines 154–163)
- `Int` (around lines 165–174)

Implementation details:
- Read the raw string with `GetString` (required/optional semantics preserved).
- Parse using `strconv.ParseInt(strVal, 10, strconv.IntSize)`.
- On parse error, append the same style of error and return `0`.
- Return `int(intVal)` directly (safe because parse is already constrained to `int` width).
- No new imports are required (`strconv` and `fmt` are already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
