### PR TITLE
fix(security): resolve remaining CodeQL alerts (3, 6, 17, 20, 22, 23, 24, 26, 27)

### DIFF
--- a/binary/attrs.go
+++ b/binary/attrs.go
@@ -152,25 +152,25 @@ func (au *AttrUtility) String(key string) string {
 }
 
 func (au *AttrUtility) OptionalInt(key string) int {
-	val, _ := au.GetInt64(key, false)
-	maxInt := int64(^uint(0) >> 1)
-	minInt := -maxInt - 1
-	if val < minInt || val > maxInt {
-		au.Errors = append(au.Errors, fmt.Errorf("int value in attribute '%s' out of range: %d", key, val))
+	if strVal, ok := au.GetString(key, false); !ok {
 		return 0
+	} else if intVal, err := strconv.ParseInt(strVal, 10, strconv.IntSize); err != nil {
+		au.Errors = append(au.Errors, fmt.Errorf("failed to parse int in attribute '%s': %w", key, err))
+		return 0
+	} else {
+		return int(intVal)
 	}
-	return int(val)
 }
 
 func (au *AttrUtility) Int(key string) int {
-	val, _ := au.GetInt64(key, true)
-	maxInt := int64(^uint(0) >> 1)
-	minInt := -maxInt - 1
-	if val < minInt || val > maxInt {
-		au.Errors = append(au.Errors, fmt.Errorf("int value in attribute '%s' out of range: %d", key, val))
+	if strVal, ok := au.GetString(key, true); !ok {
 		return 0
+	} else if intVal, err := strconv.ParseInt(strVal, 10, strconv.IntSize); err != nil {
+		au.Errors = append(au.Errors, fmt.Errorf("failed to parse int in attribute '%s': %w", key, err))
+		return 0
+	} else {
+		return int(intVal)
 	}
-	return int(val)
 }
 
 func (au *AttrUtility) Int64(key string) int64 {

--- a/group.go
+++ b/group.go
@@ -967,10 +967,11 @@ func (cli *Client) parseGroupChange(node *waBinary.Node) (*events.GroupInfo, []s
 			evt.NewInviteLink = &link
 		case "ephemeral":
 			expiration := cag.Uint64("expiration")
-			timer := uint32(expiration)
-			if expiration > math.MaxUint32 {
+			timer := uint32(math.MaxUint32)
+			if expiration <= math.MaxUint32 {
+				timer = uint32(expiration)
+			} else {
 				cag.Errors = append(cag.Errors, fmt.Errorf("value of attribute 'expiration' overflows uint32: %d", expiration))
-				timer = math.MaxUint32
 			}
 			evt.Ephemeral = &types.GroupEphemeral{
 				IsEphemeral:       true,

--- a/socket/framesocket.go
+++ b/socket/framesocket.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -133,8 +134,12 @@ func (fs *FrameSocket) SendFrame(data []byte) error {
 	}
 
 	headerLength := len(fs.Header)
+	if headerLength < 0 || dataLength < 0 || headerLength > math.MaxInt-FrameLengthSize-dataLength {
+		return fmt.Errorf("%w (got %d bytes, max %d bytes)", ErrFrameTooLarge, len(data), FrameMaxSize)
+	}
 	// Whole frame is header + 3 bytes for length + data
-	wholeFrame := make([]byte, headerLength+FrameLengthSize+dataLength)
+	totalLength := headerLength + FrameLengthSize + dataLength
+	wholeFrame := make([]byte, totalLength)
 
 	// Copy the header if it's there
 	if fs.Header != nil {

--- a/update.go
+++ b/update.go
@@ -56,7 +56,7 @@ func GetLatestVersion(ctx context.Context, httpClient *http.Client) (*store.WAVe
 		return nil, fmt.Errorf("unexpected response with status %d: %s", resp.StatusCode, data)
 	} else if match := clientVersionRegex.FindSubmatch(data); len(match) == 0 {
 		return nil, fmt.Errorf("version number not found")
-	} else if parsedVer, err := strconv.ParseInt(string(match[1]), 10, 64); err != nil {
+	} else if parsedVer, err := strconv.ParseUint(string(match[1]), 10, 32); err != nil {
 		return nil, fmt.Errorf("failed to parse version number: %w", err)
 	} else {
 		return &store.WAVersionContainer{2, 3000, uint32(parsedVer)}, nil

--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -139,13 +139,12 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	totalWithoutIV := plaintextLen + paddingLen
 	var ciphertext []byte
 	if iv == nil {
 		if plaintextLen > math.MaxInt-paddingLen-aes.BlockSize {
 			return nil, fmt.Errorf("plaintext too large: %d", plaintextLen)
 		}
-		totalWithIV := aes.BlockSize + totalWithoutIV
+		totalWithIV := paddedLen + aes.BlockSize
 		ciphertext = make([]byte, totalWithIV)
 		iv := ciphertext[:aes.BlockSize]
 		if _, err := io.ReadFull(rand.Reader, iv); err != nil {

--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -159,7 +159,7 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		if paddedLen > math.MaxInt-10 {
 			return nil, errors.New("plaintext too large")
 		}
-		ciphertext = make([]byte, paddedLen, paddedLen+10)
+		ciphertext = make([]byte, paddedLen)
 
 		cbc := cipher.NewCBCEncrypter(block, iv)
 		cbc.CryptBlocks(ciphertext, plaintextStart)

--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 )
 
@@ -125,9 +126,17 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	if len(plaintext) > math.MaxInt-paddingLen {
+		return nil, fmt.Errorf("plaintext is too large")
+	}
+	ciphertextLen := len(plaintext) + paddingLen
+
 	var ciphertext []byte
 	if iv == nil {
-		ciphertext = make([]byte, aes.BlockSize+len(plaintext)+paddingLen)
+		if ciphertextLen > math.MaxInt-aes.BlockSize {
+			return nil, fmt.Errorf("plaintext is too large")
+		}
+		ciphertext = make([]byte, aes.BlockSize+ciphertextLen)
 		iv := ciphertext[:aes.BlockSize]
 		if _, err := io.ReadFull(rand.Reader, iv); err != nil {
 			return nil, err
@@ -137,7 +146,10 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		cbc.CryptBlocks(ciphertext[aes.BlockSize:], plaintextStart)
 		cbc.CryptBlocks(ciphertext[aes.BlockSize+len(plaintextStart):], lastBlock)
 	} else {
-		ciphertext = make([]byte, len(plaintext)+paddingLen, len(plaintext)+paddingLen+10)
+		if ciphertextLen > math.MaxInt-10 {
+			return nil, fmt.Errorf("plaintext is too large")
+		}
+		ciphertext = make([]byte, ciphertextLen, ciphertextLen+10)
 
 		cbc := cipher.NewCBCEncrypter(block, iv)
 		cbc.CryptBlocks(ciphertext, plaintextStart)

--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -116,13 +116,6 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 	if plaintextLen > math.MaxInt-paddingLen {
 		return nil, errors.New("plaintext too large")
 	}
-	paddedLen := plaintextLen + paddingLen
-	if iv == nil && paddedLen > math.MaxInt-aes.BlockSize {
-		return nil, errors.New("plaintext too large")
-	}
-	if iv != nil && paddedLen > math.MaxInt-10 {
-		return nil, errors.New("plaintext too large")
-	}
 
 	plaintextStart := plaintext[:plaintextLen-sizeOfLastBlock]
 	lastBlock := append(plaintext[plaintextLen-sizeOfLastBlock:], bytes.Repeat([]byte{byte(paddingLen)}, paddingLen)...)
@@ -139,13 +132,12 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	totalWithoutIV := plaintextLen + paddingLen
 	var ciphertext []byte
 	if iv == nil {
 		if plaintextLen > math.MaxInt-paddingLen-aes.BlockSize {
 			return nil, fmt.Errorf("plaintext too large: %d", plaintextLen)
 		}
-		totalWithIV := aes.BlockSize + totalWithoutIV
+		totalWithIV := plaintextLen + paddingLen + aes.BlockSize
 		ciphertext = make([]byte, totalWithIV)
 		iv := ciphertext[:aes.BlockSize]
 		if _, err := io.ReadFull(rand.Reader, iv); err != nil {
@@ -156,9 +148,10 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		cbc.CryptBlocks(ciphertext[aes.BlockSize:], plaintextStart)
 		cbc.CryptBlocks(ciphertext[aes.BlockSize+len(plaintextStart):], lastBlock)
 	} else {
-		if paddedLen > math.MaxInt-10 {
+		if plaintextLen > math.MaxInt-paddingLen {
 			return nil, errors.New("plaintext too large")
 		}
+		paddedLen := plaintextLen + paddingLen
 		ciphertext = make([]byte, paddedLen, paddedLen+10)
 
 		cbc := cipher.NewCBCEncrypter(block, iv)


### PR DESCRIPTION
## Summary
This PR merges the remaining CodeQL security alert fixes into main from branch security.

### CodeQL Alerts Resolved:
- **Alerts 3, 6, 20, 22, 23, 24**: Size computation for allocation overflow protections in util/cbcutil/cbc.go and socket/framesocket.go.
- **Alerts 17, 26, 27**: Fixed incorrect conversion between integer types in binary/attrs.go, group.go, and update.go.

### Modified Files:
- binary/attrs.go
- group.go
- socket/framesocket.go
- update.go
- util/cbcutil/cbc.go