### PR TITLE
Potential fix for code scanning alert no. 28: Size computation for allocation may overflow

### DIFF
--- a/socket/framesocket.go
+++ b/socket/framesocket.go
@@ -134,7 +134,11 @@ func (fs *FrameSocket) SendFrame(data []byte) error {
 	}
 
 	headerLength := len(fs.Header)
-	if headerLength < 0 || dataLength < 0 || headerLength > math.MaxInt-FrameLengthSize-dataLength {
+	if headerLength > math.MaxInt-FrameLengthSize {
+		return fmt.Errorf("%w (got %d bytes, max %d bytes)", ErrFrameTooLarge, len(data), FrameMaxSize)
+	}
+	maxDataLength := math.MaxInt - headerLength - FrameLengthSize
+	if dataLength > maxDataLength {
 		return fmt.Errorf("%w (got %d bytes, max %d bytes)", ErrFrameTooLarge, len(data), FrameMaxSize)
 	}
 	// Whole frame is header + 3 bytes for length + data


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/28](https://github.com/PakaiWA/whatsmeow/security/code-scanning/28)

The best fix is to enforce a strict upper bound on the final frame allocation size before computing/allocating, using a checked-add style guard that does not rely on fragile assumptions. In general, fix this class by validating all size contributors and ensuring `a+b+c` is only performed when known to be within `int` limits (and any protocol limits).

For this code, update `SendFrame` in `socket/framesocket.go`:
- Keep the existing `dataLength >= FrameMaxSize` rejection.
- Replace the current overflow guard with a clearer two-step limit check:
  1. Reject if `headerLength > math.MaxInt-FrameLengthSize`.
  2. Compute `maxDataLength := math.MaxInt - headerLength - FrameLengthSize` and reject if `dataLength > maxDataLength`.
- Then compute `totalLength` and allocate safely.

No functionality change is intended: valid frames still pass; impossible/overflowing sizes are rejected with the same error class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
