### PR TITLE
Potential fix for code scanning alert no. 28: Size computation for allocation may overflow

### DIFF
--- a/socket/framesocket.go
+++ b/socket/framesocket.go
@@ -142,7 +142,11 @@ func (fs *FrameSocket) SendFrame(data []byte) error {
 		return fmt.Errorf("%w (got %d bytes, max %d bytes)", ErrFrameTooLarge, len(data), FrameMaxSize)
 	}
 	// Whole frame is header + 3 bytes for length + data
-	totalLength := headerLength + FrameLengthSize + dataLength
+	totalLength64 := int64(headerLength) + int64(FrameLengthSize) + int64(dataLength)
+	if totalLength64 < 0 || totalLength64 > int64(math.MaxInt) {
+		return fmt.Errorf("%w (got %d bytes, max %d bytes)", ErrFrameTooLarge, len(data), FrameMaxSize)
+	}
+	totalLength := int(totalLength64)
 	wholeFrame := make([]byte, totalLength)
 
 	// Copy the header if it's there


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/28](https://github.com/PakaiWA/whatsmeow/security/code-scanning/28)

Use overflow-safe arithmetic for the allocation size calculation in `SendFrame` so the analyzer can prove safety and runtime behavior remains unchanged.

Best fix in `socket/framesocket.go` inside `SendFrame`:
1. Keep existing frame-size policy checks.
2. Replace direct `int` addition with `math.AddInt`-style checked adds using `int64`-width helper from standard library is not available for `int`, so the cleanest approach is:
   - cast operands to `int64`,
   - compute `totalLength64 := int64(headerLength) + int64(FrameLengthSize) + int64(dataLength)`,
   - verify `totalLength64 <= math.MaxInt` (and non-negative),
   - convert to `int` only after validation.
3. Allocate with the validated `int` value.

This preserves behavior while removing overflow risk and satisfying both alert variants at the same sink.  
Only `socket/framesocket.go` needs edits; no changes are required in `handshake.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
