### PR TITLE
Potential fix for code scanning alert no. 22: Size computation for allocation may overflow

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -148,7 +148,7 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		cbc.CryptBlocks(ciphertext[aes.BlockSize:], plaintextStart)
 		cbc.CryptBlocks(ciphertext[aes.BlockSize+len(plaintextStart):], lastBlock)
 	} else {
-		ciphertext = make([]byte, paddedLen, paddedLen+10)
+		ciphertext = make([]byte, paddedLen)
 
 		cbc := cipher.NewCBCEncrypter(block, iv)
 		cbc.CryptBlocks(ciphertext, plaintextStart)


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/22](https://github.com/PakaiWA/whatsmeow/security/code-scanning/22)

The safest fix is to avoid unchecked arithmetic in allocation sizes entirely. In `util/cbcutil/cbc.go`, in `Encrypt`, replace the `else`-branch allocation from:

- `make([]byte, paddedLen, paddedLen+10)`

to

- `make([]byte, paddedLen)`

This preserves behavior (the function writes exactly `paddedLen` bytes in this branch), removes the overflow-prone `+10`, and avoids unnecessary spare capacity. No functional change is required in encryption output.

Only one file needs change:
- `util/cbcutil/cbc.go` around `Encrypt` line ~151.

No new imports, helper methods, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
