### PR TITLE
Potential fix for code scanning alert no. 33: Size computation for allocation may overflow

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -109,7 +109,13 @@ func DecryptFile(key, iv []byte, file File) error {
 Encrypt is a function that encrypts plaintext with a given key and an optional initialization vector(iv).
 */
 func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
+	const maxPlaintextLen = 64 * 1024 * 1024
+
 	plaintextLen := len(plaintext)
+	if plaintextLen > maxPlaintextLen {
+		return nil, errors.New("plaintext too large")
+	}
+
 	sizeOfLastBlock := plaintextLen % aes.BlockSize
 	paddingLen := aes.BlockSize - sizeOfLastBlock
 


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/33](https://github.com/PakaiWA/whatsmeow/security/code-scanning/33)

The best fix is to add an explicit upper bound for plaintext size in `Encrypt` before any size arithmetic/allocation. This preserves behavior for valid inputs while preventing attacker-controlled huge payloads from causing excessive allocations and also makes the overflow-safety intent unambiguous to static analysis.

Concretely, in `util/cbcutil/cbc.go` inside `Encrypt` (around lines 111–119), add a constant max plaintext size (for example `64 * 1024 * 1024`) and reject inputs larger than that with an error. Keep existing overflow checks as defense-in-depth. No import changes are needed because `errors` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
