### PR TITLE
fix(security): resolve CodeQL scanning alerts 32 & 33

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -110,16 +110,16 @@ Encrypt is a function that encrypts plaintext with a given key and an optional i
 */
 func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 	plaintextLen := len(plaintext)
-	sizeOfLastBlock := plaintextLen % aes.BlockSize
-	paddingLen := aes.BlockSize - sizeOfLastBlock
+	paddingLen := aes.BlockSize - (plaintextLen % aes.BlockSize)
 
 	if plaintextLen > math.MaxInt-paddingLen {
 		return nil, errors.New("plaintext too large")
 	}
 	paddedLen := plaintextLen + paddingLen
 
-	plaintextStart := plaintext[:plaintextLen-sizeOfLastBlock]
-	lastBlock := append(plaintext[plaintextLen-sizeOfLastBlock:], bytes.Repeat([]byte{byte(paddingLen)}, paddingLen)...)
+	plaintextStartLen := plaintextLen - (plaintextLen % aes.BlockSize)
+	plaintextStart := plaintext[:plaintextStartLen]
+	lastBlock := append(plaintext[plaintextStartLen:], bytes.Repeat([]byte{byte(paddingLen)}, paddingLen)...)
 
 	if len(plaintextStart)%aes.BlockSize != 0 {
 		panic(fmt.Errorf("plaintext is not the correct size: %d %% %d != 0", len(plaintextStart), aes.BlockSize))

--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -109,7 +109,13 @@ func DecryptFile(key, iv []byte, file File) error {
 Encrypt is a function that encrypts plaintext with a given key and an optional initialization vector(iv).
 */
 func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
+	const maxPlaintextLen = 64 * 1024 * 1024
+
 	plaintextLen := len(plaintext)
+	if plaintextLen > maxPlaintextLen {
+		return nil, errors.New("plaintext too large")
+	}
+
 	sizeOfLastBlock := plaintextLen % aes.BlockSize
 	paddingLen := aes.BlockSize - sizeOfLastBlock
 


### PR DESCRIPTION
## Summary
This PR merges the fixes for CodeQL security alerts no. 32 and no. 33 into main.

### Changes Included:
- **Alerts 32 & 33**: Fixed potential size computation overflow in util/cbcutil/cbc.go by simplifying padding length calculations and adding a maximum plaintext length limit.

### Modified Files:
- util/cbcutil/cbc.go