### PR TITLE
Potential fix for code scanning alert no. 34: Size computation for allocation may overflow

### DIFF
--- a/util/cbcutil/cbc.go
+++ b/util/cbcutil/cbc.go
@@ -116,12 +116,15 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 		return nil, errors.New("plaintext too large")
 	}
 
-	paddingLen := aes.BlockSize - (plaintextLen % aes.BlockSize)
-
-	if plaintextLen > math.MaxInt-paddingLen {
+	plaintextLenU := uint64(plaintextLen)
+	paddingLenU := uint64(aes.BlockSize) - (plaintextLenU % uint64(aes.BlockSize))
+	paddedLenU := plaintextLenU + paddingLenU
+	if paddedLenU > uint64(math.MaxInt) {
 		return nil, errors.New("plaintext too large")
 	}
-	paddedLen := plaintextLen + paddingLen
+
+	paddingLen := int(paddingLenU)
+	paddedLen := int(paddedLenU)
 
 	plaintextStartLen := plaintextLen - (plaintextLen % aes.BlockSize)
 	plaintextStart := plaintext[:plaintextStartLen]
@@ -141,10 +144,11 @@ func Encrypt(key, iv, plaintext []byte) ([]byte, error) {
 
 	var ciphertext []byte
 	if iv == nil {
-		if aes.BlockSize > math.MaxInt-paddedLen {
+		ciphertextLenU := uint64(aes.BlockSize) + paddedLenU
+		if ciphertextLenU > uint64(math.MaxInt) {
 			return nil, fmt.Errorf("plaintext too large: %d", plaintextLen)
 		}
-		ciphertextLen := aes.BlockSize + paddedLen
+		ciphertextLen := int(ciphertextLenU)
 		ciphertext = make([]byte, ciphertextLen)
 		iv := ciphertext[:aes.BlockSize]
 		if _, err := io.ReadFull(rand.Reader, iv); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/PakaiWA/whatsmeow/security/code-scanning/34](https://github.com/PakaiWA/whatsmeow/security/code-scanning/34)

To fix this robustly without changing functionality, compute padded sizes using checked arithmetic in a wider unsigned type, validate against `math.MaxInt`, then convert back to `int` only after bounds checks. This removes any ambiguity around overflow in `int` math and satisfies both allocation sites (`ciphertextLen` and `paddedLen`).

Best single fix in `util/cbcutil/cbc.go` (inside `Encrypt`):
- Keep current max-size policy (`64MB`) unchanged.
- Replace `int`-based `paddingLen`, `paddedLen`, and `ciphertextLen` arithmetic with `uint64` intermediates:
  - `plaintextLenU := uint64(len(plaintext))`
  - `paddingLenU := uint64(aes.BlockSize) - (plaintextLenU % uint64(aes.BlockSize))`
  - `paddedLenU := plaintextLenU + paddingLenU`
  - if IV is nil, `ciphertextLenU := uint64(aes.BlockSize) + paddedLenU`
- Guard each computed value with `> uint64(math.MaxInt)` before converting to `int`.
- Convert to `int` only after checks and use these safe `int` values for slicing/allocation.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
